### PR TITLE
Request token using a buildkite-agent subcommand

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -7,6 +7,10 @@ if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; 
   exit 1
 fi
 
+echo "--- :buildkite::key::aws: Requesting an OIDC token for AWS from buildkite"
+
+BUILDKITE_OIDC_TOKEN=$(buildkite-agent oidc request-token --audience sts.amazonaws.com)
+
 echo "--- :aws: Assuming role using OIDC token"
 
 echo "Role ARN: ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -9,7 +9,7 @@ fi
 
 echo "--- :buildkite::key::aws: Requesting an OIDC token for AWS from buildkite"
 
-BUILDKITE_OIDC_TOKEN=$(buildkite-agent oidc request-token --audience sts.amazonaws.com)
+BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com)"
 
 echo "--- :aws: Assuming role using OIDC token"
 


### PR DESCRIPTION
This will make this plugin independent of github.com/sj26/oidc-token-buildkite-plugin, but dependent on an as yet unreleased version of buildkite-agent.