### PR TITLE
De-emphasise log groups in plugins

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -7,11 +7,11 @@ if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; 
   exit 1
 fi
 
-echo "--- :buildkite::key::aws: Requesting an OIDC token for AWS from buildkite"
+echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from buildkite"
 
 BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com)"
 
-echo "--- :aws: Assuming role using OIDC token"
+echo "~~~ :aws: Assuming role using OIDC token"
 
 echo "Role ARN: ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"
 


### PR DESCRIPTION
It prevents the command step's logs from being expanded if the command step does not contain any log groups.

The buildkite [docs](https://buildkite.com/docs/pipelines/managing-log-output) on log grouping state:
> If no group is explicitly expanded (+++), then the last collapsed regular group (---) gets expanded instead.

This plugin created groups with `---`, but if the plugin was used on a command step that did not create any log groups of its own, it is often the case that the plugin's last log group is the last log group in the entire job log. Thus, according to the above rule, it would be expanded.

However, the agent creates log groups for each phase, including the phase that runs the command a command step. If a log group in a plugin phase is expanded, the command phase's log group is collapsed.

The result is that in many jobs, this plugin's logs are expanded and the command's logs are hidden, even when the plugin did not error. This is likely to confuse a user that didn't set up the plugin. They are more interested in the output of the command.

The screenshots should make this clearer:

Before this PR, the running a step like
```yaml
  - label: test parameter
    command: echo I am doing 🆒 stuff with the role that that I have!
    plugins:
      - aws-assume-role-with-web-identity:
          role-arn: arn:aws:iam::253213882263:role/nepa-test-get-parameter
```
hides the output of the command by default:
![2023-06-01T10:59:50,644291267+10:00](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/assets/11096602/d14d6249-d5f3-49f0-b1d1-7f8833f6d235)

With this PR, the plugin's output is hidden and the command's output is shown by default:
![2023-06-01T11:00:18,627363730+10:00](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/assets/11096602/91d85f54-e3a8-470a-a5b9-9ca2b64d23e3)

### Implementation Note
I forced all the log groups from the plugin to be de-empashised with `~~~`. It's stil the case that when there is an error, the plugin's log group is expanded:
![2023-06-01T11:07:09,452240994+10:00](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/assets/11096602/f2f9e6b2-da77-4713-bdb9-f0556a44483c)
