### PR TITLE
feat: Support passing custom session duration to assume role

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -7,9 +7,16 @@ if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; 
   exit 1
 fi
 
+REQUEST_TOKEN_OPTIONAL_ARGS=
+ASSUME_ROLE_OPTIONAL_ARGS=
+if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION:-}" ]]; then
+  REQUEST_TOKEN_OPTIONAL_ARGS="${REQUEST_TOKEN_OPTIONAL_ARGS} --lifetime ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION}"
+  ASSUME_ROLE_OPTIONAL_ARGS="${ASSUME_ROLE_OPTIONAL_ARGS} --duration-seconds ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION}"
+fi
+
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from buildkite"
 
-BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com)"
+BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com ${REQUEST_TOKEN_OPTIONAL_ARGS})"
 
 echo "~~~ :aws: Assuming role using OIDC token"
 
@@ -18,7 +25,8 @@ echo "Role ARN: ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"
 RESPONSE="$(aws sts assume-role-with-web-identity \
   --role-arn "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}" \
   --role-session-name "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}" \
-  --web-identity-token "${BUILDKITE_OIDC_TOKEN}")"
+  --web-identity-token "${BUILDKITE_OIDC_TOKEN}" \
+  ${ASSUME_ROLE_OPTIONAL_ARGS})"
 
 if [[ $? -ne 0 ]]; then
   echo "^^^ +++"

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,6 +10,8 @@ configuration:
       type: string
     role-session-name:
       type: string
+    role-session-duration:
+      type: integer
   required:
     - role-arn
   additionalProperties: false


### PR DESCRIPTION
Add new plugin parameter `role-session-duration` that will set the lifetime of the oidc requested token and the duration-seconds of the assume role with web identity session.