### PR TITLE
feat: region parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ An integer number of seconds that the assumed role session should last. Passed a
 
 Defaults to `3600` (via the AWS CLI).
 
+### `region` (optional, string)
+
+Exports `AWS_REGION` and `AWS_DEFAULT_REGION` with the value you set. If not set
+the values of `AWS_REGION` and `AWS_DEFAULT_REGION` will not be changed.
+
+Note that and `AWS_REGION` is used by the AWS CLI v2 and most SDKs.
+`AWS_DEFAULT_REGION` is included for compatibility with older SDKs and CLI
+versions.
+
 ## AWS configuration with Terraform
 
 If you automate your infrastructure with Terraform, the following configuration will setup a valid OIDC IdP in AWS -- adapted from [an example for using OIDC with EKS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster.html#enabling-iam-roles-for-service-accounts):

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use the plugin in your steps like this:
 steps:
   - command: aws sts get-caller-identity
     plugins:
-      - aws-assume-role-with-web-identity#v1.0.0:
+      - aws-assume-role-with-web-identity#v1.1.0:
           role-arn: arn:aws:iam::AWS-ACCOUNT-ID:role/SOME-ROLE
 ```
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -16,6 +16,13 @@ fi
 
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
 
+region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}"
+if [[ -n $region ]]; then
+  export AWS_REGION="$region"
+  export AWS_DEFAULT_REGION="$region"
+  echo "Using region: ${AWS_REGION}"
+fi
+
 BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com ${REQUEST_TOKEN_OPTIONAL_ARGS})"
 
 echo "~~~ :aws: Assuming role using OIDC token"

--- a/hooks/environment
+++ b/hooks/environment
@@ -16,13 +16,6 @@ fi
 
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
 
-region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}"
-if [[ -n $region ]]; then
-  export AWS_REGION="$region"
-  export AWS_DEFAULT_REGION="$region"
-  echo "Using region: ${AWS_REGION}"
-fi
-
 BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com ${REQUEST_TOKEN_OPTIONAL_ARGS})"
 
 echo "~~~ :aws: Assuming role using OIDC token"
@@ -47,3 +40,10 @@ export AWS_SECRET_ACCESS_KEY="$(jq -r ".Credentials.SecretAccessKey" <<< "${RESP
 export AWS_SESSION_TOKEN="$(jq -r ".Credentials.SessionToken" <<< "${RESPONSE}")"
 
 echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${RESPONSE}")"
+
+region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}"
+if [[ -n $region ]]; then
+  export AWS_REGION="$region"
+  export AWS_DEFAULT_REGION="$region"
+  echo "Using region: ${AWS_REGION}"
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,8 @@ configuration:
       type: string
     role-session-duration:
       type: integer
+    region:
+      type: string
   required:
     - role-arn
   additionalProperties: false

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -13,6 +13,8 @@ run_test_command() {
   echo "TESTRESULT:AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-"<value not set>"}"
   echo "TESTRESULT:AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"<value not set>"}"
   echo "TESTRESULT:AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-"<value not set>"}"
+  echo "TESTRESULT:AWS_REGION=${AWS_REGION:-"<value not set>"}"
+  echo "TESTRESULT:AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-"<value not set>"}"
 }
 
 @test "calls aws sts and exports AWS_ env vars" {
@@ -88,6 +90,53 @@ EOF
   assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=access-key-id-value"
   assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=secret-access-key-value"
   assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=session-token-value"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
+@test "passes in a custom region" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION="eu-central-1"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"
+
+  run run_test_command $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "Using region: eu-central-1"
+  assert_output --partial "Role ARN: role123"
+
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=access-key-id-value"
+  assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=secret-access-key-value"
+  assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=session-token-value"
+  assert_output --partial "TESTRESULT:AWS_REGION=eu-central-1"
+  assert_output --partial "TESTRESULT:AWS_DEFAULT_REGION=eu-central-1"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
+@test "does not pass in a custom region" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"
+
+  run run_test_command $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "Role ARN: role123"
+  assert_output --partial "Assumed role: assumed-role-id-value"
+
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=access-key-id-value"
+  assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=secret-access-key-value"
+  assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=session-token-value"
+  assert_output --partial "TESTRESULT:AWS_REGION=<value not set>"
+  assert_output --partial "TESTRESULT:AWS_DEFAULT_REGION=<value not set>"
 
   unstub aws
   unstub buildkite-agent


### PR DESCRIPTION
Adds the `region` optional parameter to the plugin.

This allows the AWS region to be set in a fashion that's compatible with all AWS SDK and CLI versions. It is not strictly required for role assumption, but experience with the [`cultureamp/aws-assume-role` plugin](https://github.com/cultureamp/aws-assume-role-buildkite-plugin) suggests that this is a highly useful feature.

It has the added benefit of easing the transition from one plugin to another significantly. The Culture Amp plugin has been the recommended plugin for some time: as companies begin to invest into moving towards OIDC, this will make the transition simple.

Also, for those companies that are seeking to automate the change from one plugin to another (as we are), this makes it dead easy.

Closes #10.

> [!IMPORTANT]
> Depends on #12 (addition of unit tests): it's expected that this PR will be merged first.