### PR TITLE
SUP-2685 - Fix shellcheck errors

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -28,7 +28,8 @@ RESPONSE="$(aws sts assume-role-with-web-identity \
   --web-identity-token "${BUILDKITE_OIDC_TOKEN}" \
   ${ASSUME_ROLE_OPTIONAL_ARGS})"
 
-if [[ $? -ne 0 ]]; then
+ASSUME_ROLE_CMD_STATUS=$?
+if [[ ${ASSUME_ROLE_CMD_STATUS} -ne 0 ]]; then
   echo "^^^ +++"
   echo "Failed to assume AWS role:"
   echo "${RESPONSE}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -7,8 +7,9 @@ if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; 
   exit 1
 fi
 
-REQUEST_TOKEN_OPTIONAL_ARGS=
-ASSUME_ROLE_OPTIONAL_ARGS=
+REQUEST_TOKEN_OPTIONAL_ARGS="${REQUEST_TOKEN_OPTIONAL_ARGS:-}"
+ASSUME_ROLE_OPTIONAL_ARGS="${ASSUME_ROLE_OPTIONAL_ARGS:-}"
+
 if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION:-}" ]]; then
   REQUEST_TOKEN_OPTIONAL_ARGS="${REQUEST_TOKEN_OPTIONAL_ARGS} --lifetime ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION}"
   ASSUME_ROLE_OPTIONAL_ARGS="${ASSUME_ROLE_OPTIONAL_ARGS} --duration-seconds ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION}"
@@ -16,23 +17,30 @@ fi
 
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
 
-BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com ${REQUEST_TOKEN_OPTIONAL_ARGS})"
+REQUEST_TOKEN_CMD="buildkite-agent oidc request-token --audience sts.amazonaws.com"
+
+if [[ -n "${REQUEST_TOKEN_OPTIONAL_ARGS:-}" ]]; then
+  REQUEST_TOKEN_CMD="${REQUEST_TOKEN_CMD} ${REQUEST_TOKEN_OPTIONAL_ARGS}"
+fi
+
+BUILDKITE_OIDC_TOKEN="$(eval "${REQUEST_TOKEN_CMD}")"
 
 echo "~~~ :aws: Assuming role using OIDC token"
-
 echo "Role ARN: ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"
 
-RESPONSE="$(aws sts assume-role-with-web-identity \
-  --role-arn "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}" \
-  --role-session-name "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}" \
-  --web-identity-token "${BUILDKITE_OIDC_TOKEN}" \
-  ${ASSUME_ROLE_OPTIONAL_ARGS})"
+ASSUME_ROLE_CMD="aws sts assume-role-with-web-identity --role-arn ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN} --role-session-name ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}} --web-identity-token ${BUILDKITE_OIDC_TOKEN}"
 
+if [[ -n "${ASSUME_ROLE_OPTIONAL_ARGS}" ]]; then
+  ASSUME_ROLE_CMD="${ASSUME_ROLE_CMD} ${ASSUME_ROLE_OPTIONAL_ARGS}"
+fi
+
+ASSUME_ROLE_RESPONSE=$(eval "${ASSUME_ROLE_CMD}")
 ASSUME_ROLE_CMD_STATUS=$?
+
 if [[ ${ASSUME_ROLE_CMD_STATUS} -ne 0 ]]; then
   echo "^^^ +++"
   echo "Failed to assume AWS role:"
-  echo "${RESPONSE}"
+  echo "${ASSUME_ROLE_RESPONSE}"
   exit 1
 fi
 
@@ -43,11 +51,10 @@ export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 export AWS_SESSION_TOKEN
 
-echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${RESPONSE}")"
+echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${ASSUME_ROLE_RESPONSE}")"
 
-region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}"
-if [[ -n $region ]]; then
-  export AWS_REGION="$region"
-  export AWS_DEFAULT_REGION="$region"
+if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}" ]]; then
+  export AWS_DEFAULT_REGION="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION}"
+  export AWS_REGION="${AWS_DEFAULT_REGION}"
   echo "Using region: ${AWS_REGION}"
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -36,9 +36,12 @@ if [[ ${ASSUME_ROLE_CMD_STATUS} -ne 0 ]]; then
   exit 1
 fi
 
-export AWS_ACCESS_KEY_ID="$(jq -r ".Credentials.AccessKeyId" <<< "${RESPONSE}")"
-export AWS_SECRET_ACCESS_KEY="$(jq -r ".Credentials.SecretAccessKey" <<< "${RESPONSE}")"
-export AWS_SESSION_TOKEN="$(jq -r ".Credentials.SessionToken" <<< "${RESPONSE}")"
+AWS_ACCESS_KEY_ID="$(jq -r ".Credentials.AccessKeyId" <<< "${ASSUME_ROLE_RESPONSE}")"
+AWS_SECRET_ACCESS_KEY="$(jq -r ".Credentials.SecretAccessKey" <<< "${ASSUME_ROLE_RESPONSE}")"
+AWS_SESSION_TOKEN="$(jq -r ".Credentials.SessionToken" <<< "${ASSUME_ROLE_RESPONSE}")"
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_SESSION_TOKEN
 
 echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${RESPONSE}")"
 


### PR DESCRIPTION
* Fixing shellcheck errors:
  * [SC2155](https://www.shellcheck.net/wiki/SC2155)
  * [SC2086](https://www.shellcheck.net/wiki/SC2086)
  * [SC2181](https://www.shellcheck.net/wiki/SC2181)
* Switch to `eval` for command execution with optionally appended arguments
  * SC2086 was the main driver for this, as the added quotes around optional args were causing test failures