### PR TITLE
Add an option to request session tags in the OIDC token

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,21 @@ An integer number of seconds that the assumed role session should last. Passed a
 
 Defaults to `3600` (via the AWS CLI).
 
-### `session-tags` (optional, string)
+### `session-tags` (optional, array)
 
-A comma separated list of [claims supported in Buildkite OIDC
+A list of [claims supported in Buildkite OIDC
 tokens](https://buildkite.com/docs/agent/v3/cli-oidc). When provided, the
 returned OIDC tokens will have the requested claims duplicated into AWS Session
 Tokens. These can then be checked in Conditions on the IAM Role Trist Policy.
 
-Eg. `organization_slug,pipeline_slug,build_branch`
+Eg.
+
+```yaml
+session-tags:
+- organization_slug
+- pipeline_slug
+- build_branch
+```
 
 Defaults to `` (empty).
 
@@ -135,7 +142,10 @@ steps:
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
           role-arn: arn:aws:iam::111111111111:role/example-role
-          session-tags: organization_slug,pipeline_slug,build_branch
+          session-tags:
+          - organization_slug
+          - pipeline_slug
+          - build_branch
 ```
 This means the trust policy on the IAM role can implement the same conditions, but avoid the error prone `sub` claim:
 
@@ -187,7 +197,9 @@ steps:
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
           role-arn: arn:aws:iam::111111111111:role/example-role
-          session-tags: organization_id,pipeline_id
+          session-tags:
+          - organization_id
+          - pipeline_id
 ```
 
 ## AWS configuration with Terraform

--- a/hooks/environment
+++ b/hooks/environment
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
 if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; then
   echo "🚨 Missing 'role-arn' plugin configuration"
   exit 1
@@ -9,7 +14,6 @@ fi
 
 role_arn=$BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN
 session_name=${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}
-session_tags="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS:-}"
 
 # prepare Buildkite command; optional args to be added before executing
 request_token_cmd=(buildkite-agent oidc request-token --audience sts.amazonaws.com)
@@ -27,13 +31,10 @@ if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURA
 fi
 
 # If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
-if [[ -n "${session_tags}" ]]; then
-  request_token_cmd+=(--aws-session-tag "${session_tags}")
-fi
-
-# If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
-if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS}" ]]; then
-  REQUEST_TOKEN_OPTIONAL_ARGS="${ASSUME_ROLE_OPTIONAL_ARGS} --aws-session-tag ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS}"
+if plugin_read_list_into_result BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS ; then
+  claims=$(join_by "," "${result[@]}")
+  request_token_cmd+=(--aws-session-tag "${claims}")
+  echo "Including session tags in OIDC request: ${claims}"
 fi
 
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"

--- a/hooks/environment
+++ b/hooks/environment
@@ -9,6 +9,7 @@ fi
 
 role_arn=$BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN
 session_name=${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}
+session_tags="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS:-}"
 
 # prepare Buildkite command; optional args to be added before executing
 request_token_cmd=(buildkite-agent oidc request-token --audience sts.amazonaws.com)
@@ -23,6 +24,16 @@ if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURA
   ttl_seconds=$(printf "%d" "$BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION")
   request_token_cmd+=(--lifetime "$ttl_seconds")
   assume_role_cmd+=(--duration-seconds "$ttl_seconds")
+fi
+
+# If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
+if [[ -n "${session_tags}" ]]; then
+  request_token_cmd+=(--aws-session-tag "${session_tags}")
+fi
+
+# If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
+if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS}" ]]; then
+  REQUEST_TOKEN_OPTIONAL_ARGS="${ASSUME_ROLE_OPTIONAL_ARGS} --aws-session-tag ${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS}"
 fi
 
 echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Reads a list from plugin config into a global result array
+# Returns success if values were read
+function plugin_read_list_into_result() {
+  result=()
+
+  for prefix in "$@" ; do
+    local i=0
+    local parameter="${prefix}_${i}"
+
+    if [[ -n "${!prefix:-}" ]] ; then
+      echo "🚨 Plugin received a string for $prefix, expected an array" >&2
+      exit 1
+    fi
+
+    while [[ -n "${!parameter:-}" ]]; do
+      result+=("${!parameter}")
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  done
+
+  [[ ${#result[@]} -gt 0 ]] || return 1
+}
+
+function join_by {
+  local IFS="$1"
+  shift
+  echo "$*";
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,7 +15,7 @@ configuration:
     region:
       type: string
     session-tags:
-      type: string
+      type: array
   required:
     - role-arn
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,6 +14,8 @@ configuration:
       type: integer
     region:
       type: string
+    session-tags:
+      type: string
   required:
     - role-arn
   additionalProperties: false

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -119,6 +119,27 @@ EOF
   unstub buildkite-agent
 }
 
+@test "passes in a set of session-tags" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS="organization_id,pipeline_id"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com --aws-session-tag organization_id,pipeline_id : echo 'buildkite-oidc-token'"
+  stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"
+
+  run run_test_command $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "Role ARN: role123"
+
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=access-key-id-value"
+  assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=secret-access-key-value"
+  assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=session-token-value"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
 @test "region not used for STS call" {
   export BUILDKITE_JOB_ID="job-uuid-42"
   export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -131,6 +131,7 @@ EOF
   run run_test_command $PWD/hooks/environment
 
   assert_success
+  assert_output --partial "Including session tags in OIDC request: organization_id,pipeline_id"
   assert_output --partial "Role ARN: role123"
 
   assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=access-key-id-value"

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -122,7 +122,8 @@ EOF
 @test "passes in a set of session-tags" {
   export BUILDKITE_JOB_ID="job-uuid-42"
   export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
-  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS="organization_id,pipeline_id"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS_0="organization_id"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS_1="pipeline_id"
 
   stub buildkite-agent "oidc request-token --audience sts.amazonaws.com --aws-session-tag organization_id,pipeline_id : echo 'buildkite-oidc-token'"
   stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"


### PR DESCRIPTION
Session tags are a more secure way for customers to define which tokens can assume an IAM role. Rather than use the error prone `sub` claim with colon separators, the trust policy of an IAM Role can target specific claims and the required values (like `organization_slug`, `pipeline_slug`, and `build_branch`.

Unfortunately any OIDC token with session tags needs an additional permission in the trust policy of the role they are assuming (`sts:TagSession`, see below). Automatically adding session tags would break role assuming for customers with existing roles and trust policies, so for now we default the option to blank and request no session tags.

Maybe in a v2.0.0 release we could invert the behaviour and default to a few commonly used session tags? I'd suggest

* organization_slug
* pipeline_slug
* build_branch

For now, users can opt in to session tags like so, using any valid claim [from the Buildkite OIDC docs](https://buildkite.com/docs/agent/v3/cli-oidc#request-oidc-token).

```yaml
steps:
  - command: aws sts get-caller-identity
    plugins:
      - aws-assume-role-with-web-identity#v1.1.0:
          role-arn: arn:aws:iam::AWS-ACCOUNT-ID:role/SOME-ROLE
          session-tags:
          - organization_slug
          - pipeline_slug
          - build_branch
```

The resulting token duplicates the requested claims into a nested `https://aws.amazon.com/tags` claim:

```json
{
  "iss": "https://agent.buildkite.com",
  "sub": "organization:example-org:pipeline:example-pipeline:ref:refs/heads/main:commit:cb9c1decb3b7c3c0fcd8a4368bb6a492e631b571:step:",
  "aud": "https://sts.amazonaws.com",
  "iat": 1739694861,
  "nbf": 1739694861,
  "exp": 1739695161,
  "organization_slug": "example-org",
  "pipeline_slug": "example-pipeline",
  "build_number": 2,
  "build_branch": "main",
  "build_tag": null,
  "build_commit": "cb9c1decb3b7c3c0fcd8a4368bb6a492e631b571",
  "step_key": null,
  "job_id": "01950de4-b414-4ef4-a604-6599c16ec9d9",
  "agent_id": "01950de4-bef7-4802-ad00-b509d14f66ab",
  "build_source": "ui",
  "runner_environment": "buildkite-hosted",
  "https://aws.amazon.com/tags": {
    "principal_tags": {
      "organization_slug": [
        "example-org"
      ],
      "pipeline_slug": [
        "example-pipeline"
      ],
      "build_branch": [
        "main"
      ]
    }
  }
}
```

Here's an example trust policy for a role that can only be assumed by `main` branch builds in the https://buildkite.com/example-org/example-pipeline pipeline

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::111111111111:oidc-provider/agent.buildkite.com"
            },
            "Action": [
                "sts:AssumeRoleWithWebIdentity",
                "sts:TagSession"
            ],
            "Condition": {
                "StringEquals": {
                    "agent.buildkite.com:aud": "sts.amazonaws.com"
                },
                "ForAnyValue:StringEquals": {
                    "aws:RequestTag/organization_slug": "example-org",
                    "aws:RequestTag/pipeline_slug": "example-pipeline",
                    "aws:RequestTag/build_branch": "main"
                }
            }
        }
    ]
}
```

Note the addition of the `sts:TagSession` action, which we previously haven't documented as required. Without this, any call to `AssumeRoleWithWebIdentity` with a token that has session tags will fail. [These docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) were useful in highlighting this requirement.