### PR TITLE
Add a pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,18 @@
+steps:  
+  - label: ":shell: Tests"
+    plugins:
+      - plugin-tester#v1.1.1:
+          folders:
+            - tests
+
+  - label: ":sparkles: Lint"
+    plugins:
+      - plugin-linter#v3.3.0:
+          id: aws-assume-role-with-web-identity
+
+  - label: ":shell: Shellcheck"
+    plugins:
+      - shellcheck#v1.4.0:
+          files:
+            - hooks/**
+            - lib/**


### PR DESCRIPTION
I noticed there is no pipeline.yml in the repo, and instead we have all the steps defined in the buildkite UI with this gem:

```yaml
    steps:
      - label: ":pipeline:"
        #command: "buildkite-agent pipeline upload" 
        command: echo "we need to add the pipeline in the repo"
```

I thought I'd be a boyscout and leave the pipeline a little better than I found it. These steps are copied directly from the UI with no changes. Once this merges, I'll remove them from the UI and change the initial step to do a proper upload.