### PR TITLE
Improve the README sample IAM policy for session tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,14 @@ steps:
           - pipeline_slug
           - build_branch
 ```
-This means the trust policy on the IAM role can implement the same conditions, but avoid the error prone `sub` claim:
+This means the trust policy on the IAM role can implement the same conditions, but avoid the error prone `sub` claim.
 
+For the conditions to pass and the role assumption to be approved, the OIDC token must:
+
+* Must match all 5 conditions (`agent.buildkite.com:aud`, `aws:RequestTag/organization_slug`, `aws:RequestTag/pipeline_slug`
+  `aws:RequestTag/build_branch` and `aws:SourceIp`). That is, they are checked with a logical AND
+* Can match `aws:RequestTag/build_branch` with either `main` or `production`. When multiple values are
+  provided for a `aws::RequestTag` condition they are checked with a logical OR
 
 ```json
 {
@@ -166,11 +172,12 @@ This means the trust policy on the IAM role can implement the same conditions, b
             "Condition": {
                 "StringEquals": {
                     "agent.buildkite.com:aud": "sts.amazonaws.com"
-                },
-                "ForAnyValue:StringEquals": {
                     "aws:RequestTag/organization_slug": "ORG_SLUG",
                     "aws:RequestTag/pipeline_slug": "PIPELINE_SLUG",
-                    "aws:RequestTag/build_branch": "main"
+                    "aws:RequestTag/build_branch": [
+                      "main",
+                      "production"
+                    ]
                 },
                 "IpAddress": {
                     "aws:SourceIp": [


### PR DESCRIPTION
I did some testing last night and I understand the logical AND/OR process for these conditions better than I did.

I also realised we don't want to recommend using `ForAnyValue`. From [2]:

> The difference between single-valued and multivalued context keys lies
> in the number of values in the request context, not the number of values
> in the policy condition

and:

> Multivalued context keys require a condition set operator. Do not use
> condition set operators ForAllValues or ForAnyValue with single-valued
> context keys

[3] Confirms that `aws:RequestTag` is a single valued type, so I don't think we should be using `ForAnyValue`. We can still provide an array of values in the policy, and they's be checked with a logical OR

Ref for the locgical AND/OR rules [1]. This diagram is useful:

![AccessPolicyLanguage_Condition_Block_AND_2 diagram](https://github.com/user-attachments/assets/adf50eb5-cb0b-4f0d-9821-bfb9887bb2f5)

Ref for the `ForAnyValue` guidance [2]

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-logic-multiple-context-keys-or-values.html
[2] https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html
[3] https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-requesttag