### PR TITLE
feat: Allow credentials env var names to be prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ data "aws_iam_policy_document" "buildkite-oidc-assume-role-trust-policy" {
 }
 ```
 
-## Credential Prefix
+## Credential Name Prefix
 
-The plugin supports a `credential-prefix` option to prefix the default AWS credential names with a specific string. This is useful when you have multiple AWS credentials in your environment and you want to avoid conflicts.
+The plugin supports a `credential-name-prefix` option to prefix the default AWS credential names with a specific string. This is useful when you have multiple AWS credentials in your environment and you want to avoid conflicts.
 
-For example, by setting `credential-prefix:MY_PREFIX_` the plugin will export `MY_PREFIX_AWS_ACCESS_KEY_ID`, `MY_PREFIX_AWS_SECRET_ACCESS_KEY` and `MY_PREFIX_AWS_SESSION_TOKEN` instead of the default `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
+For example, by setting `credential-name-prefix:MY_PREFIX_` the plugin will export `MY_PREFIX_AWS_ACCESS_KEY_ID`, `MY_PREFIX_AWS_SECRET_ACCESS_KEY` and `MY_PREFIX_AWS_SESSION_TOKEN` instead of the default `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
 
 ```yaml
 plugins:
   - aws-assume-role-with-web-identity#v1.2.0:
-      credential-prefix:MY_PREFIX_
+      credential-name-prefix:MY_PREFIX_
 ```

--- a/README.md
+++ b/README.md
@@ -269,3 +269,15 @@ data "aws_iam_policy_document" "buildkite-oidc-assume-role-trust-policy" {
   }
 }
 ```
+
+## Credential Prefix
+
+The plugin supports a `credential-prefix` option to prefix the default AWS credential names with a specific string. This is useful when you have multiple AWS credentials in your environment and you want to avoid conflicts.
+
+For example, by setting `credential-prefix:MY_PREFIX_` the plugin will export `MY_PREFIX_AWS_ACCESS_KEY_ID`, `MY_PREFIX_AWS_SECRET_ACCESS_KEY` and `MY_PREFIX_AWS_SESSION_TOKEN` instead of the default `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
+
+```yaml
+plugins:
+  - aws-assume-role-with-web-identity#v1.2.0:
+      credential-prefix:MY_PREFIX_
+```

--- a/hooks/environment
+++ b/hooks/environment
@@ -12,8 +12,8 @@ if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; 
   exit 1
 fi
 
-role_arn=$BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN
-session_name=${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}
+role_arn="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"
+session_name="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}"
 
 # prepare Buildkite command; optional args to be added before executing
 request_token_cmd=(buildkite-agent oidc request-token --audience sts.amazonaws.com)
@@ -31,7 +31,7 @@ if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURA
 fi
 
 # If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
-if plugin_read_list_into_result BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS ; then
+if plugin_read_list_into_result BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS; then
   claims=$(join_by "," "${result[@]}")
   request_token_cmd+=(--aws-session-tag "${claims}")
   echo "Including session tags in OIDC request: ${claims}"
@@ -54,18 +54,21 @@ if [[ ${assume_role_cmd_status} -ne 0 ]]; then
 fi
 
 # Use default empty prefix if not set
-CREDENTIAL_NAME_PREFIX=${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}
+CREDENTIAL_NAME_PREFIX="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}"
 
-if [ "${CREDENTIAL_NAME_PREFIX}" != "" ]; then
-  # Set prefixed variables
-  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "${assume_role_response}")"
-  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "${assume_role_response}")"
-  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<< "${assume_role_response}")"
+# Parse credentials once
+credentials=$(jq -r '.Credentials | "\(.AccessKeyId) \(.SecretAccessKey) \(.SessionToken)"' <<< "${assume_role_response}")
+read -r ACCESS_KEY_ID SECRET_ACCESS_KEY SESSION_TOKEN <<< "${credentials}"
+
+# Export credentials with or without prefix
+if [[ -n "${CREDENTIAL_NAME_PREFIX}" ]]; then
+  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=${SESSION_TOKEN}"
 else
-  # Set standard variables
-  export AWS_ACCESS_KEY_ID="$(jq -r '.Credentials.AccessKeyId' <<< "${assume_role_response}")"
-  export AWS_SECRET_ACCESS_KEY="$(jq -r '.Credentials.SecretAccessKey' <<< "${assume_role_response}")"
-  export AWS_SESSION_TOKEN="$(jq -r '.Credentials.SessionToken' <<< "${assume_role_response}")"
+  export "AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
+  export "AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+  export "AWS_SESSION_TOKEN=${SESSION_TOKEN}"
 fi
 
 echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${assume_role_response}")"

--- a/hooks/environment
+++ b/hooks/environment
@@ -56,18 +56,16 @@ fi
 # Use default empty prefix if not set
 CREDENTIAL_NAME_PREFIX=${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}
 
-# Extract credentials from assume-role response
-credentials_json="$(jq -r '.Credentials' <<< "${assume_role_response}")"
 if [ "${CREDENTIAL_NAME_PREFIX}" != "" ]; then
   # Set prefixed variables
-  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' <<< "${credentials_json}")"
-  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<< "${credentials_json}")"
-  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=$(jq -r '.SessionToken' <<< "${credentials_json}")"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "${assume_role_response}")"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "${assume_role_response}")"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<< "${assume_role_response}")"
 else
   # Set standard variables
-  export AWS_ACCESS_KEY_ID="$(jq -r '.AccessKeyId' <<< "${credentials_json}")"
-  export AWS_SECRET_ACCESS_KEY="$(jq -r '.SecretAccessKey' <<< "${credentials_json}")"
-  export AWS_SESSION_TOKEN="$(jq -r '.SessionToken' <<< "${credentials_json}")"
+  export AWS_ACCESS_KEY_ID="$(jq -r '.Credentials.AccessKeyId' <<< "${assume_role_response}")"
+  export AWS_SECRET_ACCESS_KEY="$(jq -r '.Credentials.SecretAccessKey' <<< "${assume_role_response}")"
+  export AWS_SESSION_TOKEN="$(jq -r '.Credentials.SessionToken' <<< "${assume_role_response}")"
 fi
 
 echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${assume_role_response}")"

--- a/hooks/environment
+++ b/hooks/environment
@@ -53,12 +53,22 @@ if [[ ${assume_role_cmd_status} -ne 0 ]]; then
   exit 1
 fi
 
-AWS_ACCESS_KEY_ID="$(jq -r ".Credentials.AccessKeyId" <<< "${assume_role_response}")"
-AWS_SECRET_ACCESS_KEY="$(jq -r ".Credentials.SecretAccessKey" <<< "${assume_role_response}")"
-AWS_SESSION_TOKEN="$(jq -r ".Credentials.SessionToken" <<< "${assume_role_response}")"
-export AWS_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY
-export AWS_SESSION_TOKEN
+# Use default empty prefix if not set
+CREDENTIAL_NAME_PREFIX=${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}
+
+# Extract credentials from assume-role response
+credentials_json="$(jq -r '.Credentials' <<< "${assume_role_response}")"
+if [ "${CREDENTIAL_NAME_PREFIX}" != "" ]; then
+  # Set prefixed variables
+  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' <<< "${credentials_json}")"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<< "${credentials_json}")"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=$(jq -r '.SessionToken' <<< "${credentials_json}")"
+else
+  # Set standard variables
+  export AWS_ACCESS_KEY_ID="$(jq -r '.AccessKeyId' <<< "${credentials_json}")"
+  export AWS_SECRET_ACCESS_KEY="$(jq -r '.SecretAccessKey' <<< "${credentials_json}")"
+  export AWS_SESSION_TOKEN="$(jq -r '.SessionToken' <<< "${credentials_json}")"
+fi
 
 echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${assume_role_response}")"
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -54,7 +54,7 @@ if [[ ${assume_role_cmd_status} -ne 0 ]]; then
 fi
 
 # Use default empty prefix if not set
-CREDENTIAL_NAME_PREFIX="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}"
+CREDENTIAL_NAME_PREFIX="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX:-}"
 
 # Parse credentials once
 credentials=$(jq -r '.Credentials | "\(.AccessKeyId) \(.SecretAccessKey) \(.SessionToken)"' <<< "${assume_role_response}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,8 @@ requirements:
   - jq
 configuration:
   properties:
+    credential-name-prefix:
+      type: string
     role-arn:
       type: string
     role-session-name:

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -18,8 +18,8 @@ run_test_command() {
   echo "TESTRESULT:AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-"<value not set>"}"
   
   # Add prefixed variables if prefix is set
-  if [ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}" ]; then
-    prefix="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX}"
+  if [ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX:-}" ]; then
+    prefix="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX}"
     eval "echo \"TESTRESULT:${prefix}AWS_ACCESS_KEY_ID=\${${prefix}AWS_ACCESS_KEY_ID:-'<value not set>'}\""
     eval "echo \"TESTRESULT:${prefix}AWS_SECRET_ACCESS_KEY=\${${prefix}AWS_SECRET_ACCESS_KEY:-'<value not set>'}\""
     eval "echo \"TESTRESULT:${prefix}AWS_SESSION_TOKEN=\${${prefix}AWS_SESSION_TOKEN:-'<value not set>'}\""
@@ -200,10 +200,10 @@ EOF
   unstub buildkite-agent
 }
 
-@test "uses credential prefix when specified" {
+@test "uses credential name prefix when specified" {
   export BUILDKITE_JOB_ID="job-uuid-42"
   export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
-  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX="MY_PREFIX_"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX="MY_PREFIX_"
 
   stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
   stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -10,11 +10,20 @@ load "$BATS_PLUGIN_PATH/load.bash"
 run_test_command() {
   source "$@"
 
+  # Original variables
   echo "TESTRESULT:AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-"<value not set>"}"
   echo "TESTRESULT:AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"<value not set>"}"
   echo "TESTRESULT:AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-"<value not set>"}"
   echo "TESTRESULT:AWS_REGION=${AWS_REGION:-"<value not set>"}"
   echo "TESTRESULT:AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-"<value not set>"}"
+  
+  # Add prefixed variables if prefix is set
+  if [ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX:-}" ]; then
+    prefix="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX}"
+    eval "echo \"TESTRESULT:${prefix}AWS_ACCESS_KEY_ID=\${${prefix}AWS_ACCESS_KEY_ID:-'<value not set>'}\""
+    eval "echo \"TESTRESULT:${prefix}AWS_SECRET_ACCESS_KEY=\${${prefix}AWS_SECRET_ACCESS_KEY:-'<value not set>'}\""
+    eval "echo \"TESTRESULT:${prefix}AWS_SESSION_TOKEN=\${${prefix}AWS_SESSION_TOKEN:-'<value not set>'}\""
+  fi
 }
 
 @test "calls aws sts and exports AWS_ env vars" {
@@ -186,6 +195,34 @@ EOF
   assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=session-token-value"
   assert_output --partial "TESTRESULT:AWS_REGION=<value not set>"
   assert_output --partial "TESTRESULT:AWS_DEFAULT_REGION=<value not set>"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
+@test "uses credential prefix when specified" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_PREFIX="MY_PREFIX_"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"
+
+  run run_test_command $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "Role ARN: role123"
+  assert_output --partial "Assumed role: assumed-role-id-value"
+
+  # Check that prefixed environment variables are set
+  assert_output --partial "TESTRESULT:MY_PREFIX_AWS_ACCESS_KEY_ID=access-key-id-value"
+  assert_output --partial "TESTRESULT:MY_PREFIX_AWS_SECRET_ACCESS_KEY=secret-access-key-value"
+  assert_output --partial "TESTRESULT:MY_PREFIX_AWS_SESSION_TOKEN=session-token-value"
+
+  # Original variables should not be set
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=<value not set>"
+  assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=<value not set>"
+  assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=<value not set>"
 
   unstub aws
   unstub buildkite-agent


### PR DESCRIPTION
### Context

Implements https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/issues/23.

### Intent

 - Add an env var that can be used to add a prefix to the name of the standard AWS credentials env vars to prevent collisions