### PR TITLE
Add hook parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ For example, by setting `credential-name-prefix:MY_PREFIX_` the plugin will expo
 plugins:
   - aws-assume-role-with-web-identity#v1.3.0:
       credential-name-prefix:MY_PREFIX_
+
+### `hook` (optional, string)
+
+The hook to run. Can be either `environment` (the default) or `pre-command`.
+
+Useful for when using a plugin such as the `artifacts` plugin that runs as a
+`pre-command` hook, and you need that to run with the pipeline role before then
+assuming your IAM role like so:
+```
+    plugins:
+      - artifacts#v1.9.4:
+          download: "out/*"
+      - aws-assume-role-with-web-identity#v1.3.0
+          hook: pre-command
+          role-arn: arn:aws:iam::111111111111:role/example-role
 ```
 
 ## IAM Role Trust Policies

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For example, by setting `credential-name-prefix:MY_PREFIX_` the plugin will expo
 plugins:
   - aws-assume-role-with-web-identity#v1.3.0:
       credential-name-prefix:MY_PREFIX_
+```
 
 ### `hook` (optional, string)
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -2,79 +2,17 @@
 
 set -euo pipefail
 
+# This is the default hook to run if the hook parameter is not set.
+
+HOOK_PARAM="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_HOOK:-}"
+if [[ -z "$HOOK_PARAM" || "$HOOK_PARAM" == "environment" ]]; then
+	echo "Running in the environment hook"
+else
+	echo "Skipping environment hook"
+	exit 0
+fi
+
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck source=lib/shared.bash
-. "$DIR/../lib/shared.bash"
-
-if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; then
-  echo "🚨 Missing 'role-arn' plugin configuration"
-  exit 1
-fi
-
-role_arn="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"
-session_name="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}"
-
-# prepare Buildkite command; optional args to be added before executing
-request_token_cmd=(buildkite-agent oidc request-token --audience sts.amazonaws.com)
-
-# prepare AWS command; OIDC token and optional args to be added before executing
-assume_role_cmd=(aws sts assume-role-with-web-identity
-  --role-arn "$role_arn"
-  --role-session-name "$session_name")
-
-# optionally add the session duration to Buildkite and AWS commands
-if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION:-}" ]]; then
-  ttl_seconds=$(printf "%d" "$BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION")
-  request_token_cmd+=(--lifetime "$ttl_seconds")
-  assume_role_cmd+=(--duration-seconds "$ttl_seconds")
-fi
-
-# If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
-if plugin_read_list_into_result BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS; then
-  claims=$(join_by "," "${result[@]}")
-  request_token_cmd+=(--aws-session-tag "${claims}")
-  echo "Including session tags in OIDC request: ${claims}"
-fi
-
-echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
-buildkite_oidc_token=$("${request_token_cmd[@]}")
-
-echo "~~~ :aws: Assuming role using OIDC token"
-echo "Role ARN: ${role_arn}"
-assume_role_cmd+=(--web-identity-token "$buildkite_oidc_token")
-assume_role_response=$("${assume_role_cmd[@]}")
-assume_role_cmd_status=$?
-
-if [[ ${assume_role_cmd_status} -ne 0 ]]; then
-  echo "^^^ +++"
-  echo "Failed to assume AWS role:"
-  echo "${assume_role_response}"
-  exit 1
-fi
-
-# Use default empty prefix if not set
-CREDENTIAL_NAME_PREFIX="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX:-}"
-
-# Parse credentials once
-credentials=$(jq -r '.Credentials | "\(.AccessKeyId) \(.SecretAccessKey) \(.SessionToken)"' <<< "${assume_role_response}")
-read -r ACCESS_KEY_ID SECRET_ACCESS_KEY SESSION_TOKEN <<< "${credentials}"
-
-# Export credentials with or without prefix
-if [[ -n "${CREDENTIAL_NAME_PREFIX}" ]]; then
-  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
-  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
-  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=${SESSION_TOKEN}"
-else
-  export "AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
-  export "AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
-  export "AWS_SESSION_TOKEN=${SESSION_TOKEN}"
-fi
-
-echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${assume_role_response}")"
-
-if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}" ]]; then
-  export AWS_DEFAULT_REGION="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION}"
-  export AWS_REGION="${AWS_DEFAULT_REGION}"
-  echo "Using region: ${AWS_REGION}"
-fi
+# shellcheck source=lib/plugin.bash
+. "$DIR/../lib/plugin.bash"

--- a/hooks/environment
+++ b/hooks/environment
@@ -13,4 +13,5 @@ fi
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-"$DIR/../lib/plugin.bash"
+# shellcheck source=lib/plugin.bash
+. "$DIR/../lib/plugin.bash"

--- a/hooks/environment
+++ b/hooks/environment
@@ -4,8 +4,7 @@ set -euo pipefail
 
 # This is the default hook to run if the hook parameter is not set.
 
-HOOK_PARAM="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_HOOK:-}"
-if [[ -z "$HOOK_PARAM" || "$HOOK_PARAM" == "environment" ]]; then
+if [[ "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_HOOK:-environment}" == "environment" ]]; then
 	echo "Running in the environment hook"
 else
 	echo "Skipping environment hook"

--- a/hooks/environment
+++ b/hooks/environment
@@ -14,5 +14,4 @@ fi
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck source=lib/plugin.bash
-. "$DIR/../lib/plugin.bash"
+"$DIR/../lib/plugin.bash"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,5 +13,4 @@ fi
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck source=lib/plugin.bash
-. "$DIR/../lib/plugin.bash"
+"$DIR/../lib/plugin.bash"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,4 +13,5 @@ fi
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-"$DIR/../lib/plugin.bash"
+# shellcheck source=lib/plugin.bash
+. "$DIR/../lib/plugin.bash"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This hook only runs if the hook parameter is set to "pre-command".
+
+if [[ "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_HOOK:-}" == "pre-command" ]]; then
+	echo "Running in the pre-command hook"
+else
+	echo "Skipping pre-command hook"
+	exit 0
+fi
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/plugin.bash
+. "$DIR/../lib/plugin.bash"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck source=shared.bash
+# shellcheck source=lib/shared.bash
 . "$DIR/shared.bash"
 
 if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; then

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=shared.bash
+. "$DIR/shared.bash"
+
+if [[ -z "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN:-}" ]]; then
+  echo "🚨 Missing 'role-arn' plugin configuration"
+  exit 1
+fi
+
+role_arn="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN}"
+session_name="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_NAME:-buildkite-job-${BUILDKITE_JOB_ID}}"
+
+# prepare Buildkite command; optional args to be added before executing
+request_token_cmd=(buildkite-agent oidc request-token --audience sts.amazonaws.com)
+
+# prepare AWS command; OIDC token and optional args to be added before executing
+assume_role_cmd=(aws sts assume-role-with-web-identity
+  --role-arn "$role_arn"
+  --role-session-name "$session_name")
+
+# optionally add the session duration to Buildkite and AWS commands
+if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION:-}" ]]; then
+  ttl_seconds=$(printf "%d" "$BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_SESSION_DURATION")
+  request_token_cmd+=(--lifetime "$ttl_seconds")
+  assume_role_cmd+=(--duration-seconds "$ttl_seconds")
+fi
+
+# If the user has provided a specific set of claims to include in the token as AWS session tags, we'll request them
+if plugin_read_list_into_result BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_SESSION_TAGS; then
+  claims=$(join_by "," "${result[@]}")
+  request_token_cmd+=(--aws-session-tag "${claims}")
+  echo "Including session tags in OIDC request: ${claims}"
+fi
+
+echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from Buildkite"
+buildkite_oidc_token=$("${request_token_cmd[@]}")
+
+echo "~~~ :aws: Assuming role using OIDC token"
+echo "Role ARN: ${role_arn}"
+assume_role_cmd+=(--web-identity-token "$buildkite_oidc_token")
+assume_role_response=$("${assume_role_cmd[@]}")
+assume_role_cmd_status=$?
+
+if [[ ${assume_role_cmd_status} -ne 0 ]]; then
+  echo "^^^ +++"
+  echo "Failed to assume AWS role:"
+  echo "${assume_role_response}"
+  exit 1
+fi
+
+# Use default empty prefix if not set
+CREDENTIAL_NAME_PREFIX="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX:-}"
+
+# Parse credentials once
+credentials=$(jq -r '.Credentials | "\(.AccessKeyId) \(.SecretAccessKey) \(.SessionToken)"' <<< "${assume_role_response}")
+read -r ACCESS_KEY_ID SECRET_ACCESS_KEY SESSION_TOKEN <<< "${credentials}"
+
+# Export credentials with or without prefix
+if [[ -n "${CREDENTIAL_NAME_PREFIX}" ]]; then
+  export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+  export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=${SESSION_TOKEN}"
+else
+  export "AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
+  export "AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+  export "AWS_SESSION_TOKEN=${SESSION_TOKEN}"
+fi
+
+echo "Assumed role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${assume_role_response}")"
+
+if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}" ]]; then
+  export AWS_DEFAULT_REGION="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION}"
+  export AWS_REGION="${AWS_DEFAULT_REGION}"
+  echo "Using region: ${AWS_REGION}"
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,6 +8,8 @@ configuration:
   properties:
     credential-name-prefix:
       type: string
+    hook:
+      type: string
     role-arn:
       type: string
     role-session-name:

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -47,6 +47,28 @@ run_test_command() {
   unstub buildkite-agent
 }
 
+@test "calls aws sts and exports AWS_ env vars in pre-command hook" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_HOOK="pre-command"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json"
+
+  run run_test_command $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "Role ARN: role123"
+  assert_output --partial "Assumed role: assumed-role-id-value"
+
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=access-key-id-value"
+  assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=secret-access-key-value"
+  assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=session-token-value"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
 @test "failure to get token" {
   export BUILDKITE_JOB_ID="job-uuid-42"
   export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
@@ -226,4 +248,14 @@ EOF
 
   unstub aws
   unstub buildkite-agent
+
+@test "environment hook does nothing when configured to use the pre-command hook" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_HOOK="pre-command"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+
+  run run_test_command $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "Skipping environment hook"
 }

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -16,7 +16,7 @@ run_test_command() {
   echo "TESTRESULT:AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-"<value not set>"}"
   echo "TESTRESULT:AWS_REGION=${AWS_REGION:-"<value not set>"}"
   echo "TESTRESULT:AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-"<value not set>"}"
-  
+
   # Add prefixed variables if prefix is set
   if [ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX:-}" ]; then
     prefix="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX}"
@@ -248,6 +248,7 @@ EOF
 
   unstub aws
   unstub buildkite-agent
+}
 
 @test "environment hook does nothing when configured to use the pre-command hook" {
   export BUILDKITE_JOB_ID="job-uuid-42"


### PR DESCRIPTION
Add the ability to run this as either an environment hook or pre-command hook with the former being the default.
The behaviour is chosen via a new hook parameter.

I tried switching from the cultureamp/aws-assume-role plugin to this one but found steps using the artifacts plugin were failing. It is because this plugin was running before the artifacts had a chance to run, and so the role being assumed was not able to access our artifacts S3 bucket. The plugin we switched from ran as a pre-command hook and didn't suffer from this problem.

Move the code for the plugin from hooks/environment to a shared lib/plugin.bash script.
Update hooks/environment to call the shared code if the new hook parameter is unset (making it the default) or set to environment. Create hooks/pre-command to call the shared code if the new hook parameter is set to pre-command.

Add some tests.

Add details to the README.md file for the new hook and provide an example.