### PR TITLE
feat: chain role assume

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ plugins:
       credential-name-prefix:MY_PREFIX_
 ```
 
+### `chain-role-arn` (optional, string)
+
+ARN of a second IAM role to assume after the initial OIDC-based role assumption. Useful for multi-account setups where the OIDC provider only exists in one account (e.g. an Identity Account), but the target resources live in another account.
+
+The typical pattern is: Buildkite OIDC → entry role in Identity Account → `sts:AssumeRole` into Target Account.
+
+```yaml
+plugins:
+  - aws-assume-role-with-web-identity#v1.6.0:
+      role-arn: arn:aws:iam::IDENTITY-ACCOUNT-ID:role/CI-ENTRY-ROLE
+      chain-role-arn: arn:aws:iam::TARGET-ACCOUNT-ID:role/TARGET-ROLE
+```
+
+The chained `sts:AssumeRole` call uses the credentials obtained from the first hop, so the entry role must have `sts:AssumeRole` permission on the target role. The final exported credentials will be those of the chained role.
+
+When `credential-name-prefix` is also set, the chained credentials are exported under the same prefix.
+
+### `chain-role-session-duration` (optional, integer)
+
+An integer number of seconds for the chained role session. Passed as `--duration-seconds` to `sts:AssumeRole`. Defaults to `3600` (via the AWS CLI) when not set.
+
+Only used when `chain-role-arn` is also set.
+
 ### `hook` (optional, string)
 
 The hook to run. Can be either `environment` (the default) or `pre-command`.

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -115,3 +115,54 @@ if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_REGION:-}" ]]; th
   export AWS_REGION="${AWS_DEFAULT_REGION}"
   echo "Using region: ${AWS_REGION}"
 fi
+
+# Optionally chain a second role assumption (sts:AssumeRole using credentials from the first hop)
+if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_ARN:-}" ]]; then
+  chain_role_arn="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_ARN}"
+  chain_session_name="buildkite-job-${BUILDKITE_JOB_ID}"
+
+  chain_role_cmd=(aws sts assume-role
+    --role-arn "${chain_role_arn}"
+    --role-session-name "${chain_session_name}")
+
+  if [[ -n "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_SESSION_DURATION:-}" ]]; then
+    chain_role_cmd+=(--duration-seconds "${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_SESSION_DURATION}")
+  fi
+
+  echo "~~~ :aws: Chaining role assumption"
+  echo "Role ARN: ${chain_role_arn}"
+
+  # Pass credentials explicitly so the chain hop works even when credential-name-prefix is set
+  chain_role_stderr=$(mktemp)
+  chain_role_response=$(
+    AWS_ACCESS_KEY_ID="${ACCESS_KEY_ID}" \
+    AWS_SECRET_ACCESS_KEY="${SECRET_ACCESS_KEY}" \
+    AWS_SESSION_TOKEN="${SESSION_TOKEN}" \
+    "${chain_role_cmd[@]}" 2>"$chain_role_stderr"
+  ) || chain_role_cmd_status=$?
+  chain_role_err=$(<"$chain_role_stderr")
+  rm -f "$chain_role_stderr"
+
+  if [[ ${chain_role_cmd_status:-0} -ne 0 ]]; then
+    echo "^^^ +++"
+    echo "Failed to assume chained role: ${chain_role_arn}"
+    echo ""
+    echo "${chain_role_err}"
+    exit 1
+  fi
+
+  chain_credentials=$(jq -r '.Credentials | "\(.AccessKeyId) \(.SecretAccessKey) \(.SessionToken)"' <<< "${chain_role_response}")
+  read -r ACCESS_KEY_ID SECRET_ACCESS_KEY SESSION_TOKEN <<< "${chain_credentials}"
+
+  if [[ -n "${CREDENTIAL_NAME_PREFIX}" ]]; then
+    export "${CREDENTIAL_NAME_PREFIX}AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
+    export "${CREDENTIAL_NAME_PREFIX}AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+    export "${CREDENTIAL_NAME_PREFIX}AWS_SESSION_TOKEN=${SESSION_TOKEN}"
+  else
+    export "AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}"
+    export "AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+    export "AWS_SESSION_TOKEN=${SESSION_TOKEN}"
+  fi
+
+  echo "Assumed chained role: $(jq -r .AssumedRoleUser.AssumedRoleId <<< "${chain_role_response}")"
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -22,6 +22,10 @@ configuration:
       type: string
     session-tags:
       type: array
+    chain-role-arn:
+      type: string
+    chain-role-session-duration:
+      type: integer
   required:
     - role-arn
   additionalProperties: false

--- a/tests/chain-sts.json
+++ b/tests/chain-sts.json
@@ -1,0 +1,11 @@
+{
+  "Credentials": {
+    "SecretAccessKey": "chain-secret-access-key-value",
+    "SessionToken": "chain-session-token-value",
+    "Expiration": "...",
+    "AccessKeyId": "chain-access-key-id-value"
+  },
+  "AssumedRoleUser": {
+    "AssumedRoleId": "chain-assumed-role-id-value"
+  }
+}

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -394,6 +394,103 @@ run_test_command() {
   unstub buildkite-agent
 }
 
+@test "chains a second role assumption when chain-role-arn is set" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_ARN="chain-role456"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws \
+    "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json" \
+    "sts assume-role --role-arn chain-role456 --role-session-name buildkite-job-job-uuid-42 : cat tests/chain-sts.json"
+
+  run run_test_command
+
+  assert_success
+  assert_output --partial "Role ARN: role123"
+  assert_output --partial "Assumed role: assumed-role-id-value"
+  assert_output --partial "Role ARN: chain-role456"
+  assert_output --partial "Assumed chained role: chain-assumed-role-id-value"
+
+  # Final credentials should be those from the chained role
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=chain-access-key-id-value"
+  assert_output --partial "TESTRESULT:AWS_SECRET_ACCESS_KEY=chain-secret-access-key-value"
+  assert_output --partial "TESTRESULT:AWS_SESSION_TOKEN=chain-session-token-value"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
+@test "chains a second role assumption with custom session duration" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_ARN="chain-role456"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_SESSION_DURATION="7200"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws \
+    "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json" \
+    "sts assume-role --role-arn chain-role456 --role-session-name buildkite-job-job-uuid-42 --duration-seconds 7200 : cat tests/chain-sts.json"
+
+  run run_test_command
+
+  assert_success
+  assert_output --partial "Assumed chained role: chain-assumed-role-id-value"
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=chain-access-key-id-value"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
+@test "failure to assume chained role exits with error" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_ARN="chain-role456"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws \
+    "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json" \
+    "sts assume-role --role-arn chain-role456 --role-session-name buildkite-job-job-uuid-42 : echo 'AccessDenied' >&2; exit 1"
+
+  run run_test_command
+
+  assert_failure
+  assert_output --partial "^^^ +++"
+  assert_output --partial "Failed to assume chained role: chain-role456"
+  assert_output --partial "AccessDenied"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
+@test "chains a second role assumption and respects credential name prefix" {
+  export BUILDKITE_JOB_ID="job-uuid-42"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CHAIN_ROLE_ARN="chain-role456"
+  export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_CREDENTIAL_NAME_PREFIX="MY_PREFIX_"
+
+  stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+  stub aws \
+    "sts assume-role-with-web-identity --role-arn role123 --role-session-name buildkite-job-job-uuid-42 --web-identity-token buildkite-oidc-token : cat tests/sts.json" \
+    "sts assume-role --role-arn chain-role456 --role-session-name buildkite-job-job-uuid-42 : cat tests/chain-sts.json"
+
+  run run_test_command
+
+  assert_success
+  assert_output --partial "Assumed chained role: chain-assumed-role-id-value"
+
+  # Final prefixed credentials should be from the chained role
+  assert_output --partial "TESTRESULT:MY_PREFIX_AWS_ACCESS_KEY_ID=chain-access-key-id-value"
+  assert_output --partial "TESTRESULT:MY_PREFIX_AWS_SECRET_ACCESS_KEY=chain-secret-access-key-value"
+  assert_output --partial "TESTRESULT:MY_PREFIX_AWS_SESSION_TOKEN=chain-session-token-value"
+
+  # Standard vars should remain unset
+  assert_output --partial "TESTRESULT:AWS_ACCESS_KEY_ID=<value not set>"
+
+  unstub aws
+  unstub buildkite-agent
+}
+
 @test "uses credential name prefix when specified" {
   export BUILDKITE_JOB_ID="job-uuid-42"
   export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"


### PR DESCRIPTION
## Add support for chained role assumption

### Why

The plugin currently supports a single OIDC-based role assumption `sts:AssumeRoleWithWebIdentity`). This is sufficient for single-account setups, but breaks down in a common multi-account pattern:

- The Buildkite OIDC identity provider is configured in an **Identity Account**
- Target resources (S3, ECR, etc.) live in a separate **Target Account**
- The entry role in the Identity Account has `sts:AssumeRole` permission on a role in the Target Account

`sts:AssumeRoleWithWebIdentity` is a one-shot exchange — it can only reach roles in accounts that have the OIDC provider configured. The second hop into the Target Account requires a regular `sts:AssumeRole` call using the credentials obtained from the first hop.

### What

Adds two optional configuration parameters:

- **`chain-role-arn`** (string): ARN of a second IAM role to assume via `sts:AssumeRole` after the initial OIDC hop. When set, the final exported credentials are those of the chained role.
- **`chain-role-session-duration`** (integer): Duration in seconds for the chained role session (defaults to 3600 via the AWS CLI).

```yaml
steps:
  - command: deploy.sh
    plugins:
      - aws-assume-role-with-web-identity#vX.X.X:
          role-arn: arn:aws:iam::IDENTITY-ACCOUNT-ID:role/CI-ENTRY-ROLE
          chain-role-arn: arn:aws:iam::TARGET-ACCOUNT-ID:role/TARGET-ROLE
```

Implementation notes

- The chain hop credentials are passed explicitly to the aws sts assume-role subprocess, so it works correctly even when credential-name-prefix is set (in that case the standard AWS_* env vars aren't exported, so the AWS CLI wouldn't otherwise pick them up).
- credential-name-prefix is respected for the final credentials: the chained role's credentials are exported under the same prefix as the first hop.
- Failure in the chain hop hard-fails the build, consistent with the existing behaviour for the first hop.

Test plan

- Basic chain role assumption replaces first-hop credentials
- chain-role-session-duration is forwarded as --duration-seconds
- Failure in chain hop produces a clear error and exits non-zero
- credential-name-prefix is respected for chained credentials
- All existing tests continue to pass (24/24)